### PR TITLE
Secret agent hints

### DIFF
--- a/src/applet-device-wifi.c
+++ b/src/applet-device-wifi.c
@@ -1643,7 +1643,10 @@ wifi_get_secrets (SecretsRequest *req, GError **error)
 
 	g_return_val_if_fail (!info->dialog, FALSE);
 
-	info->dialog = nma_wifi_dialog_new (req->applet->nm_client, req->connection, NULL, NULL, TRUE);
+	info->dialog = nma_wifi_dialog_new_for_secrets (req->applet->nm_client,
+	                                                req->connection,
+	                                                req->setting_name,
+	                                                (const char *const*) req->hints);
 	if (info->dialog) {
 		applet_secrets_request_set_free_func (req, free_wifi_info);
 		g_signal_connect (info->dialog, "response",

--- a/src/connection-editor/page-8021x-security.c
+++ b/src/connection-editor/page-8021x-security.c
@@ -68,7 +68,7 @@ finish_setup (CEPage8021xSecurity *self, gpointer user_data)
 	CEPage8021xSecurityPrivate *priv = CE_PAGE_8021X_SECURITY_GET_PRIVATE (self);
 	GtkWidget *parent_container;
 
-	priv->security = (WirelessSecurity *) ws_wpa_eap_new (parent->connection, TRUE, FALSE);
+	priv->security = (WirelessSecurity *) ws_wpa_eap_new (parent->connection, TRUE, FALSE, NULL);
 	if (!priv->security) {
 		g_warning ("Could not load 802.1X user interface.");
 		return;

--- a/src/connection-editor/page-wifi-security.c
+++ b/src/connection-editor/page-wifi-security.c
@@ -411,7 +411,7 @@ finish_setup (CEPageWifiSecurity *self, gpointer user_data)
 	if (security_valid (NMU_SEC_WPA_ENTERPRISE, mode) || security_valid (NMU_SEC_WPA2_ENTERPRISE, mode)) {
 		WirelessSecurityWPAEAP *ws_wpa_eap;
 
-		ws_wpa_eap = ws_wpa_eap_new (connection, TRUE, FALSE);
+		ws_wpa_eap = ws_wpa_eap_new (connection, TRUE, FALSE, NULL);
 		if (ws_wpa_eap) {
 			add_security_item (self, WIRELESS_SECURITY (ws_wpa_eap), sec_model,
 			                   &iter, _("WPA & WPA2 Enterprise"), FALSE, FALSE);

--- a/src/ethernet-dialog.c
+++ b/src/ethernet-dialog.c
@@ -57,7 +57,7 @@ dialog_set_security (NMConnection *connection,
 	GList *iter;
 	WirelessSecurity *security;
 
-	security = (WirelessSecurity *) ws_wpa_eap_new (connection, FALSE, TRUE);
+	security = (WirelessSecurity *) ws_wpa_eap_new (connection, FALSE, TRUE, NULL);
 
 	/* Remove any previous wireless security widgets */
 	children = gtk_container_get_children (GTK_CONTAINER (box));

--- a/src/libnm-gtk/nm-wifi-dialog.c
+++ b/src/libnm-gtk/nm-wifi-dialog.c
@@ -983,7 +983,7 @@ security_combo_init (NMAWifiDialog *self, gboolean secrets_only)
 	    || nm_utils_security_valid (NMU_SEC_WPA2_ENTERPRISE, dev_caps, !!priv->ap, is_adhoc, ap_flags, ap_wpa, ap_rsn)) {
 		WirelessSecurityWPAEAP *ws_wpa_eap;
 
-		ws_wpa_eap = ws_wpa_eap_new (priv->connection, FALSE, secrets_only);
+		ws_wpa_eap = ws_wpa_eap_new (priv->connection, FALSE, secrets_only, NULL);
 		if (ws_wpa_eap) {
 			add_security_item (self, WIRELESS_SECURITY (ws_wpa_eap), sec_model,
 			                   &iter, _("WPA & WPA2 Enterprise"));

--- a/src/libnma/libnma.ver
+++ b/src/libnma/libnma.ver
@@ -99,3 +99,7 @@ global:
 libnma_1_8_12 {
 	nma_mobile_wizard_get_type;
 } libnma_1_8_0;
+
+libnma_1_8_20 {
+	nma_wifi_dialog_new_for_secrets;
+} libnma_1_8_12;

--- a/src/libnma/nma-wifi-dialog.c
+++ b/src/libnma/nma-wifi-dialog.c
@@ -85,7 +85,9 @@ enum {
 #define C_SEP_COLUMN		2
 #define C_NEW_COLUMN		3
 
-static gboolean security_combo_init (NMAWifiDialog *self, gboolean secrets_only);
+static gboolean security_combo_init (NMAWifiDialog *self, gboolean secrets_only,
+                                     const char *secrets_setting_name,
+                                     const char *const*secrets_hints);
 static void ssid_entry_changed (GtkWidget *entry, gpointer user_data);
 
 void
@@ -375,7 +377,7 @@ connection_combo_changed (GtkWidget *combo,
 	if (priv->connection)
 		eap_method_ca_cert_ignore_load (priv->connection);
 
-	if (!security_combo_init (self, priv->secrets_only)) {
+	if (!security_combo_init (self, priv->secrets_only, NULL, NULL)) {
 		g_warning ("Couldn't change Wi-Fi security combo box.");
 		return;
 	}
@@ -586,7 +588,7 @@ device_combo_changed (GtkWidget *combo,
 		return;
 	}
 
-	if (!security_combo_init (self, priv->secrets_only)) {
+	if (!security_combo_init (self, priv->secrets_only, NULL, NULL)) {
 		g_warning ("Couldn't change Wi-Fi security combo box.");
 		return;
 	}
@@ -836,7 +838,8 @@ out:
 }
 
 static gboolean
-security_combo_init (NMAWifiDialog *self, gboolean secrets_only)
+security_combo_init (NMAWifiDialog *self, gboolean secrets_only,
+                     const char *secrets_setting_name, const char *const*secrets_hints)
 {
 	NMAWifiDialogPrivate *priv;
 	GtkListStore *sec_model;
@@ -865,7 +868,8 @@ security_combo_init (NMAWifiDialog *self, gboolean secrets_only)
 	/* The security options displayed are filtered based on device
 	 * capabilities, and if provided, additionally by access point capabilities.
 	 * If a connection is given, that connection's options should be selected
-	 * by default.
+	 * by default.  If hints is non-empty only filter based on the setting
+	 * keys on the hints list.
 	 */
 	dev_caps = nm_device_wifi_get_capabilities (NM_DEVICE_WIFI (priv->device));
 	if (priv->ap != NULL) {
@@ -982,8 +986,12 @@ security_combo_init (NMAWifiDialog *self, gboolean secrets_only)
 	if (   nm_utils_security_valid (NMU_SEC_WPA_ENTERPRISE, dev_caps, !!priv->ap, is_adhoc, ap_flags, ap_wpa, ap_rsn)
 	    || nm_utils_security_valid (NMU_SEC_WPA2_ENTERPRISE, dev_caps, !!priv->ap, is_adhoc, ap_flags, ap_wpa, ap_rsn)) {
 		WirelessSecurityWPAEAP *ws_wpa_eap;
+		const char *const*hints = NULL;
 
-		ws_wpa_eap = ws_wpa_eap_new (priv->connection, FALSE, secrets_only);
+		if (secrets_setting_name && !strcmp (secrets_setting_name, NM_SETTING_802_1X_SETTING_NAME))
+			hints = secrets_hints;
+
+		ws_wpa_eap = ws_wpa_eap_new (priv->connection, FALSE, secrets_only, hints);
 		if (ws_wpa_eap) {
 			add_security_item (self, WIRELESS_SECURITY (ws_wpa_eap), sec_model,
 			                   &iter, _("WPA & WPA2 Enterprise"));
@@ -1038,7 +1046,9 @@ static gboolean
 internal_init (NMAWifiDialog *self,
                NMConnection *specific_connection,
                NMDevice *specific_device,
-               gboolean secrets_only)
+               gboolean secrets_only,
+               const char *secrets_setting_name,
+               const char *const*secrets_hints)
 {
 	NMAWifiDialogPrivate *priv = NMA_WIFI_DIALOG_GET_PRIVATE (self);
 	GtkWidget *widget;
@@ -1111,7 +1121,7 @@ internal_init (NMAWifiDialog *self,
 		return FALSE;
 	}
 
-	if (!security_combo_init (self, priv->secrets_only)) {
+	if (!security_combo_init (self, priv->secrets_only, secrets_setting_name, secrets_hints)) {
 		g_warning ("Couldn't set up Wi-Fi security combo box.");
 		return FALSE;
 	}
@@ -1269,26 +1279,20 @@ nma_wifi_dialog_get_connection (NMAWifiDialog *self,
 	return connection;
 }
 
-GtkWidget *
-nma_wifi_dialog_new (NMClient *client,
+static GtkWidget *
+internal_new_dialog (NMClient *client,
                      NMConnection *connection,
                      NMDevice *device,
                      NMAccessPoint *ap,
-                     gboolean secrets_only)
+                     gboolean secrets_only,
+                     const char *secrets_setting_name,
+                     const char *const*secrets_hints)
 {
 	NMAWifiDialog *self;
 	NMAWifiDialogPrivate *priv;
-	guint32 dev_caps;
 
 	g_return_val_if_fail (NM_IS_CLIENT (client), NULL);
 	g_return_val_if_fail (NM_IS_CONNECTION (connection), NULL);
-
-	/* Ensure device validity */
-	if (device) {
-		dev_caps = nm_device_get_capabilities (device);
-		g_return_val_if_fail (dev_caps & NM_DEVICE_CAP_NM_SUPPORTED, NULL);
-		g_return_val_if_fail (NM_IS_DEVICE_WIFI (device), NULL);
-	}
 
 	self = NMA_WIFI_DIALOG (g_object_new (NMA_TYPE_WIFI_DIALOG, NULL));
 	if (self) {
@@ -1304,7 +1308,7 @@ nma_wifi_dialog_new (NMClient *client,
 		/* Handle CA cert ignore stuff */
 		eap_method_ca_cert_ignore_load (connection);
 
-		if (!internal_init (self, connection, device, secrets_only)) {
+		if (!internal_init (self, connection, device, secrets_only, secrets_setting_name, secrets_hints)) {
 			g_warning ("Couldn't create Wi-Fi security dialog.");
 			gtk_widget_destroy (GTK_WIDGET (self));
 			self = NULL;
@@ -1312,6 +1316,86 @@ nma_wifi_dialog_new (NMClient *client,
 	}
 
 	return GTK_WIDGET (self);
+}
+
+/**
+ * nma_wifi_dialog_new:
+ * @client: client to retrieve list of devices or connections from
+ * @connection: connection to be shown/edited or %NULL
+ * @device: device to check connection compatibility against
+ * @ap: AP to check connection compatibility against
+ * @secrets_only: whether to only ask for secrets for given connection
+ *
+ * Creates a wifi connection dialog and populates it with settings from
+ * @connection if given.  If @device is not given a device selection combo box
+ * will be included.  If @connection is not given a connection selection combo
+ * box will be included.  If @secrets_only is %FALSE a complete connection
+ * creator/editor dialog is returned, otherwise only wifi security secrets
+ * relevant to the security settings in @connection are going to be shown and
+ * will be editable.
+ *
+ * Returns: the dialog widget or %NULL in case of error
+ */
+GtkWidget *
+nma_wifi_dialog_new (NMClient *client,
+                     NMConnection *connection,
+                     NMDevice *device,
+                     NMAccessPoint *ap,
+                     gboolean secrets_only)
+{
+	guint32 dev_caps;
+
+	/* Ensure device validity */
+	if (device) {
+		dev_caps = nm_device_get_capabilities (device);
+		g_return_val_if_fail (dev_caps & NM_DEVICE_CAP_NM_SUPPORTED, NULL);
+		g_return_val_if_fail (NM_IS_DEVICE_WIFI (device), NULL);
+	}
+
+	return internal_new_dialog (client,
+	                            connection,
+	                            device,
+	                            ap,
+	                            secrets_only,
+	                            NULL,
+	                            NULL);
+}
+
+/**
+ * nma_wifi_dialog_new_for_secrets:
+ * @client: client to retrieve list of devices or connections from
+ * @connection: connection for which secrets are requested
+ * @secrets_setting_name: setting name whose secrets are requested
+ *   or %NULL
+ * @secrets_hints: array of setting key names within the setting given in
+ *   @secrets_setting_name which are requested or %NULL
+ *
+ * Creates a wifi secrets dialog and populates it with setting values from
+ * @connection.  If @secrets_setting_name and @secrets_hints are not given
+ * this function creates an identical dialog as nma_wifi_dialog_new() would
+ * create with the @secrets_only parameter %TRUE.  Otherwise
+ * @secrets_setting_name and @secrets_hints determine the list of specific
+ * secrets that are being requested from the user and no editable entries
+ * are shown for any other settings.
+ *
+ * Note: only a subset of all settings and setting keys is supported as
+ * @secrets_setting_name and @secrets_hints.
+ *
+ * Returns: the dialog widget or %NULL in case of error
+ */
+GtkWidget *
+nma_wifi_dialog_new_for_secrets (NMClient *client,
+                                 NMConnection *connection,
+                                 const char *secrets_setting_name,
+                                 const char *const*secrets_hints)
+{
+	return internal_new_dialog (client,
+	                            connection,
+	                            NULL,
+	                            NULL,
+	                            TRUE,
+	                            secrets_setting_name,
+	                            secrets_hints);
 }
 
 static GtkWidget *
@@ -1334,7 +1418,7 @@ internal_new_operation (NMClient *client,
 	priv->group = gtk_size_group_new (GTK_SIZE_GROUP_HORIZONTAL);
 	priv->operation = operation;
 
-	if (!internal_init (self, NULL, NULL, FALSE)) {
+	if (!internal_init (self, NULL, NULL, FALSE, NULL, NULL)) {
 		g_warning ("Couldn't create Wi-Fi security dialog.");
 		gtk_widget_destroy (GTK_WIDGET (self));
 		return NULL;

--- a/src/libnma/nma-wifi-dialog.c
+++ b/src/libnma/nma-wifi-dialog.c
@@ -321,6 +321,8 @@ ssid_entry_changed (GtkWidget *entry, gpointer user_data)
 	if (!ssid)
 		goto out;
 
+	g_bytes_unref (ssid);
+
 	model = gtk_combo_box_get_model (GTK_COMBO_BOX (priv->sec_combo));
 	if (gtk_combo_box_get_active_iter (GTK_COMBO_BOX (priv->sec_combo), &iter))
 		gtk_tree_model_get (model, &iter, S_SEC_COLUMN, &sec, -1);
@@ -1203,6 +1205,7 @@ nma_wifi_dialog_get_connection (NMAWifiDialog *self,
 	if (!priv->connection) {
 		NMSettingConnection *s_con;
 		char *uuid;
+		GBytes *ssid;
 
 		connection = nm_simple_connection_new ();
 
@@ -1216,7 +1219,9 @@ nma_wifi_dialog_get_connection (NMAWifiDialog *self,
 		nm_connection_add_setting (connection, (NMSetting *) s_con);
 
 		s_wireless = (NMSettingWireless *) nm_setting_wireless_new ();
-		g_object_set (s_wireless, NM_SETTING_WIRELESS_SSID, validate_dialog_ssid (self), NULL);
+		ssid = validate_dialog_ssid (self);
+		g_object_set (s_wireless, NM_SETTING_WIRELESS_SSID, ssid, NULL);
+		g_free (ssid);
 
 		if (priv->operation == OP_CREATE_ADHOC) {
 			NMSetting *s_ip4;

--- a/src/libnma/nma-wifi-dialog.c
+++ b/src/libnma/nma-wifi-dialog.c
@@ -1009,7 +1009,14 @@ security_combo_init (NMAWifiDialog *self, gboolean secrets_only,
 	 * will already be populated with secrets.  If no connection was given,
 	 * then we need to get any existing secrets to populate the dialog with.
 	 */
-	setting_name = priv->connection ? nm_connection_need_secrets (priv->connection, NULL) : NULL;
+	if (priv->connection) {
+		if (secrets_setting_name)
+			setting_name = secrets_setting_name;
+		else
+			setting_name = nm_connection_need_secrets (priv->connection, NULL);
+	} else
+		setting_name = NULL;
+
 	if (setting_name && NM_IS_REMOTE_CONNECTION (priv->connection)) {
 		GetSecretsInfo *info;
 

--- a/src/libnma/nma-wifi-dialog.h
+++ b/src/libnma/nma-wifi-dialog.h
@@ -53,6 +53,11 @@ GtkWidget *nma_wifi_dialog_new (NMClient *client,
                                 NMAccessPoint *ap,
                                 gboolean secrets_only);
 
+GtkWidget *nma_wifi_dialog_new_for_secrets (NMClient *client,
+                                            NMConnection *connection,
+                                            const char *secrets_setting_name,
+                                            const char *const*secrets_hints);
+
 GtkWidget *nma_wifi_dialog_new_for_hidden (NMClient *client);
 
 GtkWidget *nma_wifi_dialog_new_for_create (NMClient *client);

--- a/src/wireless-security/eap-method-fast.c
+++ b/src/wireless-security/eap-method-fast.c
@@ -261,7 +261,8 @@ inner_auth_combo_init (EAPMethodFAST *method,
 	em_gtc = eap_method_simple_new (method->sec_parent,
 	                                connection,
 	                                EAP_METHOD_SIMPLE_TYPE_GTC,
-	                                simple_flags);
+	                                simple_flags,
+	                                NULL);
 	gtk_list_store_append (auth_model, &iter);
 	gtk_list_store_set (auth_model, &iter,
 	                    I_NAME_COLUMN, _("GTC"),
@@ -276,7 +277,8 @@ inner_auth_combo_init (EAPMethodFAST *method,
 	em_mschap_v2 = eap_method_simple_new (method->sec_parent,
 	                                      connection,
 	                                      EAP_METHOD_SIMPLE_TYPE_MSCHAP_V2,
-	                                      simple_flags);
+	                                      simple_flags,
+	                                      NULL);
 	gtk_list_store_append (auth_model, &iter);
 	gtk_list_store_set (auth_model, &iter,
 	                    I_NAME_COLUMN, _("MSCHAPv2"),

--- a/src/wireless-security/eap-method-peap.c
+++ b/src/wireless-security/eap-method-peap.c
@@ -293,7 +293,8 @@ inner_auth_combo_init (EAPMethodPEAP *method,
 	em_mschap_v2 = eap_method_simple_new (method->sec_parent,
 	                                      connection,
 	                                      EAP_METHOD_SIMPLE_TYPE_MSCHAP_V2,
-	                                      simple_flags);
+	                                      simple_flags,
+	                                      NULL);
 	gtk_list_store_append (auth_model, &iter);
 	gtk_list_store_set (auth_model, &iter,
 	                    I_NAME_COLUMN, _("MSCHAPv2"),
@@ -308,7 +309,8 @@ inner_auth_combo_init (EAPMethodPEAP *method,
 	em_md5 = eap_method_simple_new (method->sec_parent,
 	                                connection,
 	                                EAP_METHOD_SIMPLE_TYPE_MD5,
-	                                simple_flags);
+	                                simple_flags,
+	                                NULL);
 	gtk_list_store_append (auth_model, &iter);
 	gtk_list_store_set (auth_model, &iter,
 	                    I_NAME_COLUMN, _("MD5"),
@@ -323,7 +325,8 @@ inner_auth_combo_init (EAPMethodPEAP *method,
 	em_gtc = eap_method_simple_new (method->sec_parent,
 	                                connection,
 	                                EAP_METHOD_SIMPLE_TYPE_GTC,
-	                                simple_flags);
+	                                simple_flags,
+	                                NULL);
 	gtk_list_store_append (auth_model, &iter);
 	gtk_list_store_set (auth_model, &iter,
 	                    I_NAME_COLUMN, _("GTC"),

--- a/src/wireless-security/eap-method-simple.c
+++ b/src/wireless-security/eap-method-simple.c
@@ -381,8 +381,8 @@ eap_method_simple_new (WirelessSecurity *ws_parent,
 	method->flags = flags;
 	method->type = type;
 	g_assert (type < EAP_METHOD_SIMPLE_TYPE_LAST);
-	g_assert (   (flags & EAP_METHOD_SIMPLE_FLAG_SECRETS_ONLY)
-	          || type != EAP_METHOD_SIMPLE_TYPE_UNKNOWN);
+	g_assert (   type != EAP_METHOD_SIMPLE_TYPE_UNKNOWN
+	          || hints);
 
 	if (hints) {
 		for (; *hints; hints++) {

--- a/src/wireless-security/eap-method-simple.c
+++ b/src/wireless-security/eap-method-simple.c
@@ -40,19 +40,33 @@ struct _EAPMethodSimple {
 	EAPMethodSimpleType type;
 	EAPMethodSimpleFlags flags;
 
+	gboolean username_requested;
+	gboolean password_requested;
+	gboolean pkey_passphrase_requested;
 	GtkEntry *username_entry;
 	GtkEntry *password_entry;
 	GtkToggleButton *show_password;
+	GtkEntry *pkey_passphrase_entry;
+	GtkToggleButton *show_pkey_passphrase;
 	guint idle_func_id;
 };
 
 static void
-show_toggled_cb (GtkToggleButton *button, EAPMethodSimple *method)
+show_password_toggled_cb (GtkToggleButton *button, EAPMethodSimple *method)
 {
 	gboolean visible;
 
 	visible = gtk_toggle_button_get_active (button);
 	gtk_entry_set_visibility (method->password_entry, visible);
+}
+
+static void
+show_pkey_passphrase_toggled_cb (GtkToggleButton *button, EAPMethodSimple *method)
+{
+	gboolean visible;
+
+	visible = gtk_toggle_button_get_active (button);
+	gtk_entry_set_visibility (method->pkey_passphrase_entry, visible);
 }
 
 static gboolean
@@ -69,27 +83,43 @@ validate (EAPMethod *parent, GError **error)
 	const char *text;
 	gboolean ret = TRUE;
 
-	text = gtk_entry_get_text (method->username_entry);
-	if (!text || !strlen (text)) {
-		widget_set_error (GTK_WIDGET (method->username_entry));
-		g_set_error_literal (error, NMA_ERROR, NMA_ERROR_GENERIC, _("missing EAP username"));
-		ret = FALSE;
-	} else
-		widget_unset_error (GTK_WIDGET (method->username_entry));
+	if (method->username_requested) {
+		text = gtk_entry_get_text (method->username_entry);
+		if (!text || !strlen (text)) {
+			widget_set_error (GTK_WIDGET (method->username_entry));
+			g_set_error_literal (error, NMA_ERROR, NMA_ERROR_GENERIC, _("missing EAP username"));
+			ret = FALSE;
+		} else
+			widget_unset_error (GTK_WIDGET (method->username_entry));
+	}
 
 	/* Check if the password should always be requested */
-	if (always_ask_selected (method->password_entry))
-		widget_unset_error (GTK_WIDGET (method->password_entry));
-	else {
-		text = gtk_entry_get_text (method->password_entry);
-		if (!text || !strlen (text)) {
-			widget_set_error (GTK_WIDGET (method->password_entry));
-			if (ret) {
-				g_set_error_literal (error, NMA_ERROR, NMA_ERROR_GENERIC, _("missing EAP password"));
-				ret = FALSE;
-			}
-		} else
+	if (method->password_requested) {
+		if (always_ask_selected (method->password_entry))
 			widget_unset_error (GTK_WIDGET (method->password_entry));
+		else {
+			text = gtk_entry_get_text (method->password_entry);
+			if (!text || !strlen (text)) {
+				widget_set_error (GTK_WIDGET (method->password_entry));
+				if (ret) {
+					g_set_error_literal (error, NMA_ERROR, NMA_ERROR_GENERIC,
+					                     _("missing EAP password"));
+					ret = FALSE;
+				}
+			} else
+				widget_unset_error (GTK_WIDGET (method->password_entry));
+		}
+	}
+
+	if (method->pkey_passphrase_requested) {
+		text = gtk_entry_get_text (method->pkey_passphrase_entry);
+		if (!text || !strlen (text)) {
+			widget_set_error (GTK_WIDGET (method->pkey_passphrase_entry));
+			g_set_error_literal (error, NMA_ERROR, NMA_ERROR_GENERIC,
+			                     _("missing EAP client Private Key passphrase"));
+			ret = FALSE;
+		} else
+			widget_unset_error (GTK_WIDGET (method->pkey_passphrase_entry));
 	}
 
 	return ret;
@@ -98,15 +128,26 @@ validate (EAPMethod *parent, GError **error)
 static void
 add_to_size_group (EAPMethod *parent, GtkSizeGroup *group)
 {
+	EAPMethodSimple *method = (EAPMethodSimple *) parent;
 	GtkWidget *widget;
 
-	widget = GTK_WIDGET (gtk_builder_get_object (parent->builder, "eap_simple_username_label"));
-	g_assert (widget);
-	gtk_size_group_add_widget (group, widget);
+	if (method->username_requested) {
+		widget = GTK_WIDGET (gtk_builder_get_object (parent->builder, "eap_simple_username_label"));
+		g_assert (widget);
+		gtk_size_group_add_widget (group, widget);
+	}
 
-	widget = GTK_WIDGET (gtk_builder_get_object (parent->builder, "eap_simple_password_label"));
-	g_assert (widget);
-	gtk_size_group_add_widget (group, widget);
+	if (method->password_requested) {
+		widget = GTK_WIDGET (gtk_builder_get_object (parent->builder, "eap_simple_password_label"));
+		g_assert (widget);
+		gtk_size_group_add_widget (group, widget);
+	}
+
+	if (method->pkey_passphrase_requested) {
+		widget = GTK_WIDGET (gtk_builder_get_object (parent->builder, "eap_simple_pkey_passphrase_label"));
+		g_assert (widget);
+		gtk_size_group_add_widget (group, widget);
+	}
 }
 
 typedef struct {
@@ -124,6 +165,7 @@ static const EapType eap_table[EAP_METHOD_SIMPLE_TYPE_LAST] = {
 	[EAP_METHOD_SIMPLE_TYPE_PWD]             = { "pwd",      TRUE  },
 	[EAP_METHOD_SIMPLE_TYPE_CHAP]            = { "chap",     FALSE },
 	[EAP_METHOD_SIMPLE_TYPE_GTC]             = { "gtc",      TRUE  },
+	[EAP_METHOD_SIMPLE_TYPE_UNKNOWN]         = { "unknown",  TRUE  },
 };
 
 static void
@@ -138,51 +180,64 @@ fill_connection (EAPMethod *parent, NMConnection *connection)
 	s_8021x = nm_connection_get_setting_802_1x (connection);
 	g_assert (s_8021x);
 
-	/* If this is the main EAP method, clear any existing methods because the
-	 * user-selected on will replace it.
-	 */
-	if (parent->phase2 == FALSE)
-		nm_setting_802_1x_clear_eap_methods (s_8021x);
-
-	eap_type = &eap_table[method->type];
-	if (parent->phase2) {
-		/* If the outer EAP method (TLS, TTLS, PEAP, etc) allows inner/phase2
-		 * EAP methods (which only TTLS allows) *and* the inner/phase2 method
-		 * supports being an inner EAP method, then set PHASE2_AUTHEAP.
-		 * Otherwise the inner/phase2 method goes into PHASE2_AUTH.
-		 */
-		if ((method->flags & EAP_METHOD_SIMPLE_FLAG_AUTHEAP_ALLOWED) && eap_type->autheap_allowed) {
-			g_object_set (s_8021x, NM_SETTING_802_1X_PHASE2_AUTHEAP, eap_type->name, NULL);
-			g_object_set (s_8021x, NM_SETTING_802_1X_PHASE2_AUTH, NULL, NULL);
-		} else {
-			g_object_set (s_8021x, NM_SETTING_802_1X_PHASE2_AUTH, eap_type->name, NULL);
-			g_object_set (s_8021x, NM_SETTING_802_1X_PHASE2_AUTHEAP, NULL, NULL);
-		}
-	} else
-		nm_setting_802_1x_add_eap_method (s_8021x, eap_type->name);
-
-	g_object_set (s_8021x, NM_SETTING_802_1X_IDENTITY, gtk_entry_get_text (method->username_entry), NULL);
-
-	/* Save the password always ask setting */
-	not_saved = always_ask_selected (method->password_entry);
-	flags = nma_utils_menu_to_secret_flags (GTK_WIDGET (method->password_entry));
-	nm_setting_set_secret_flags (NM_SETTING (s_8021x), NM_SETTING_802_1X_PASSWORD, flags, NULL);
-
-	/* Fill the connection's password if we're in the applet so that it'll get
-	 * back to NM.  From the editor though, since the connection isn't going
-	 * back to NM in response to a GetSecrets() call, we don't save it if the
-	 * user checked "Always Ask".
-	 */
-	if (!(method->flags & EAP_METHOD_SIMPLE_FLAG_IS_EDITOR) || not_saved == FALSE)
-		g_object_set (s_8021x, NM_SETTING_802_1X_PASSWORD, gtk_entry_get_text (method->password_entry), NULL);
-
-	/* Update secret flags and popup when editing the connection */
 	if (!(method->flags & EAP_METHOD_SIMPLE_FLAG_SECRETS_ONLY)) {
-		GtkWidget *passwd_entry = GTK_WIDGET (gtk_builder_get_object (parent->builder, "eap_simple_password_entry"));
-		g_assert (passwd_entry);
+		/* If this is the main EAP method, clear any existing methods because the
+		 * user-selected one will replace it.
+		 */
+		if (parent->phase2 == FALSE)
+			nm_setting_802_1x_clear_eap_methods (s_8021x);
 
-		nma_utils_update_password_storage (passwd_entry, flags,
-		                                   NM_SETTING (s_8021x), method->password_flags_name);
+		eap_type = &eap_table[method->type];
+		if (parent->phase2) {
+			/* If the outer EAP method (TLS, TTLS, PEAP, etc) allows inner/phase2
+			 * EAP methods (which only TTLS allows) *and* the inner/phase2 method
+			 * supports being an inner EAP method, then set PHASE2_AUTHEAP.
+			 * Otherwise the inner/phase2 method goes into PHASE2_AUTH.
+			 */
+			if ((method->flags & EAP_METHOD_SIMPLE_FLAG_AUTHEAP_ALLOWED) && eap_type->autheap_allowed) {
+				g_object_set (s_8021x, NM_SETTING_802_1X_PHASE2_AUTHEAP, eap_type->name, NULL);
+				g_object_set (s_8021x, NM_SETTING_802_1X_PHASE2_AUTH, NULL, NULL);
+			} else {
+				g_object_set (s_8021x, NM_SETTING_802_1X_PHASE2_AUTH, eap_type->name, NULL);
+				g_object_set (s_8021x, NM_SETTING_802_1X_PHASE2_AUTHEAP, NULL, NULL);
+			}
+		} else
+			nm_setting_802_1x_add_eap_method (s_8021x, eap_type->name);
+	}
+
+	if (method->username_requested)
+		g_object_set (s_8021x, NM_SETTING_802_1X_IDENTITY, gtk_entry_get_text (method->username_entry), NULL);
+
+	if (method->password_requested) {
+		/* Save the password always ask setting */
+		not_saved = always_ask_selected (method->password_entry);
+		flags = nma_utils_menu_to_secret_flags (GTK_WIDGET (method->password_entry));
+		nm_setting_set_secret_flags (NM_SETTING (s_8021x), method->password_flags_name, flags, NULL);
+
+		/* Fill the connection's password if we're in the applet so that it'll get
+		 * back to NM.  From the editor though, since the connection isn't going
+		 * back to NM in response to a GetSecrets() call, we don't save it if the
+		 * user checked "Always Ask".
+		 */
+		if (!(method->flags & EAP_METHOD_SIMPLE_FLAG_IS_EDITOR) || not_saved == FALSE) {
+			g_object_set (s_8021x, NM_SETTING_802_1X_PASSWORD,
+			              gtk_entry_get_text (method->password_entry), NULL);
+		}
+
+		/* Update secret flags and popup when editing the connection */
+		if (!(method->flags & EAP_METHOD_SIMPLE_FLAG_SECRETS_ONLY)) {
+			GtkWidget *passwd_entry = GTK_WIDGET (gtk_builder_get_object (parent->builder,
+			                                                              "eap_simple_password_entry"));
+			g_assert (passwd_entry);
+
+			nma_utils_update_password_storage (passwd_entry, flags,
+			                                   NM_SETTING (s_8021x), method->password_flags_name);
+		}
+	}
+
+	if (method->pkey_passphrase_requested) {
+		g_object_set (s_8021x, NM_SETTING_802_1X_PRIVATE_KEY_PASSWORD,
+		              gtk_entry_get_text (method->pkey_passphrase_entry), NULL);
 	}
 }
 
@@ -194,6 +249,11 @@ update_secrets (EAPMethod *parent, NMConnection *connection)
 	                          "eap_simple_password_entry",
 	                          NM_TYPE_SETTING_802_1X,
 	                          (HelperSecretFunc) nm_setting_802_1x_get_password);
+	helper_fill_secret_entry (connection,
+	                          parent->builder,
+	                          "eap_simple_pkey_passphrase_entry",
+	                          NM_TYPE_SETTING_802_1X,
+	                          (HelperSecretFunc) nm_setting_802_1x_get_private_key_password);
 }
 
 static gboolean
@@ -276,20 +336,31 @@ destroy (EAPMethod *parent)
 	g_signal_handlers_disconnect_by_data (method->password_entry, method->ws_parent);
 	g_signal_handlers_disconnect_by_data (method->password_entry, method);
 	g_signal_handlers_disconnect_by_data (method->show_password, method);
+	g_signal_handlers_disconnect_by_data (method->pkey_passphrase_entry, method->ws_parent);
+	g_signal_handlers_disconnect_by_data (method->show_pkey_passphrase, method);
 
 	nm_clear_g_source (&method->idle_func_id);
+}
+
+static void
+hide_row (GtkWidget **widgets, size_t num)
+{
+	while (num--)
+		gtk_widget_hide (*widgets++);
 }
 
 EAPMethodSimple *
 eap_method_simple_new (WirelessSecurity *ws_parent,
                        NMConnection *connection,
                        EAPMethodSimpleType type,
-                       EAPMethodSimpleFlags flags)
+                       EAPMethodSimpleFlags flags,
+                       const char *const*hints)
 {
 	EAPMethod *parent;
 	EAPMethodSimple *method;
 	GtkWidget *widget;
 	NMSetting8021x *s_8021x = NULL;
+	GtkWidget *widget_row[10];
 
 	parent = eap_method_init (sizeof (EAPMethodSimple),
 	                          validate,
@@ -310,6 +381,23 @@ eap_method_simple_new (WirelessSecurity *ws_parent,
 	method->flags = flags;
 	method->type = type;
 	g_assert (type < EAP_METHOD_SIMPLE_TYPE_LAST);
+	g_assert (   (flags & EAP_METHOD_SIMPLE_FLAG_SECRETS_ONLY)
+	          || type != EAP_METHOD_SIMPLE_TYPE_UNKNOWN);
+
+	if (hints) {
+		for (; *hints; hints++) {
+			if (!strcmp (*hints, NM_SETTING_802_1X_IDENTITY))
+				method->username_requested = TRUE;
+			else if (!strcmp (*hints, NM_SETTING_802_1X_PASSWORD)) {
+				method->password_requested = TRUE;
+				method->password_flags_name = NM_SETTING_802_1X_PASSWORD;
+			} else if (!strcmp (*hints, NM_SETTING_802_1X_PRIVATE_KEY_PASSWORD))
+				method->pkey_passphrase_requested = TRUE;
+		}
+	} else {
+		method->username_requested = TRUE;
+		method->password_requested = TRUE;
+	}
 
 	widget = GTK_WIDGET (gtk_builder_get_object (parent->builder, "eap_simple_notebook"));
 	g_assert (widget);
@@ -327,7 +415,8 @@ eap_method_simple_new (WirelessSecurity *ws_parent,
 	                  (GCallback) wireless_security_changed_cb,
 	                  ws_parent);
 
-	if (method->flags & EAP_METHOD_SIMPLE_FLAG_SECRETS_ONLY)
+	if (   (method->flags & EAP_METHOD_SIMPLE_FLAG_SECRETS_ONLY)
+	    && !method->username_requested)
 		gtk_widget_set_sensitive (widget, FALSE);
 
 	widget = GTK_WIDGET (gtk_builder_get_object (parent->builder, "eap_simple_password_entry"));
@@ -351,8 +440,39 @@ eap_method_simple_new (WirelessSecurity *ws_parent,
 	g_assert (widget);
 	method->show_password = GTK_TOGGLE_BUTTON (widget);
 	g_signal_connect (G_OBJECT (widget), "toggled",
-	                  (GCallback) show_toggled_cb,
+	                  (GCallback) show_password_toggled_cb,
 	                  method);
+
+	widget = GTK_WIDGET (gtk_builder_get_object (parent->builder, "eap_simple_pkey_passphrase_entry"));
+	g_assert (widget);
+	method->pkey_passphrase_entry = GTK_ENTRY (widget);
+	g_signal_connect (G_OBJECT (widget), "changed",
+	                  (GCallback) wireless_security_changed_cb,
+	                  ws_parent);
+
+	widget = GTK_WIDGET (gtk_builder_get_object (parent->builder, "eap_simple_show_pkey_passphrase_checkbutton"));
+	g_assert (widget);
+	method->show_pkey_passphrase = GTK_TOGGLE_BUTTON (widget);
+	g_signal_connect (G_OBJECT (widget), "toggled",
+	                  (GCallback) show_pkey_passphrase_toggled_cb,
+	                  method);
+
+	widget_row[0] = GTK_WIDGET (gtk_builder_get_object (parent->builder, "eap_simple_username_label"));
+	widget_row[1] = GTK_WIDGET (gtk_builder_get_object (parent->builder, "eap_simple_username_entry"));
+	if (!method->username_requested)
+		hide_row (widget_row, 2);
+
+	widget_row[0] = GTK_WIDGET (gtk_builder_get_object (parent->builder, "eap_simple_password_label"));
+	widget_row[1] = GTK_WIDGET (gtk_builder_get_object (parent->builder, "eap_simple_password_entry"));
+	widget_row[2] = GTK_WIDGET (gtk_builder_get_object (parent->builder, "show_checkbutton_eapsimple"));
+	if (!method->password_requested)
+		hide_row (widget_row, 3);
+
+	widget_row[0] = GTK_WIDGET (gtk_builder_get_object (parent->builder, "eap_simple_pkey_passphrase_label"));
+	widget_row[1] = GTK_WIDGET (gtk_builder_get_object (parent->builder, "eap_simple_pkey_passphrase_entry"));
+	widget_row[2] = GTK_WIDGET (gtk_builder_get_object (parent->builder, "eap_simple_show_pkey_passphrase_checkbutton"));
+	if (!method->pkey_passphrase_requested)
+		hide_row (widget_row, 3);
 
 	/* Initialize the UI fields with the security settings from method->ws_parent.
 	 * This will be done again when the widget gets realized. It must be done here as well,
@@ -364,4 +484,3 @@ eap_method_simple_new (WirelessSecurity *ws_parent,
 
 	return method;
 }
-

--- a/src/wireless-security/eap-method-simple.h
+++ b/src/wireless-security/eap-method-simple.h
@@ -35,6 +35,7 @@ typedef enum {
 	EAP_METHOD_SIMPLE_TYPE_PWD,
 	EAP_METHOD_SIMPLE_TYPE_CHAP,
 	EAP_METHOD_SIMPLE_TYPE_GTC,
+	EAP_METHOD_SIMPLE_TYPE_UNKNOWN,
 
 	/* Boundary value, do not use */
 	EAP_METHOD_SIMPLE_TYPE_LAST
@@ -57,7 +58,8 @@ typedef struct _EAPMethodSimple EAPMethodSimple;
 EAPMethodSimple *eap_method_simple_new (WirelessSecurity *ws_parent,
                                         NMConnection *connection,
                                         EAPMethodSimpleType type,
-                                        EAPMethodSimpleFlags flags);
+                                        EAPMethodSimpleFlags flags,
+                                        const char *const*hints);
 
 #endif /* EAP_METHOD_SIMPLE_H */
 

--- a/src/wireless-security/eap-method-simple.ui
+++ b/src/wireless-security/eap-method-simple.ui
@@ -97,6 +97,50 @@
           </packing>
         </child>
         <child>
+          <object class="GtkLabel" id="eap_simple_pkey_passphrase_label">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">P_rivate Key Passphrase</property>
+            <property name="use_underline">True</property>
+            <property name="mnemonic_widget">eap_simple_password_entry</property>
+            <property name="xalign">1</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkEntry" id="eap_simple_pkey_passphrase_entry">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="hexpand">True</property>
+            <property name="visibility">False</property>
+            <property name="activates_default">True</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="eap_simple_show_pkey_passphrase_checkbutton">
+            <property name="label" translatable="yes">Sh_ow passphrase</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="use_underline">True</property>
+            <property name="draw_indicator">True</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">4</property>
+          </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
           <placeholder/>
         </child>
       </object>

--- a/src/wireless-security/eap-method-ttls.c
+++ b/src/wireless-security/eap-method-ttls.c
@@ -281,7 +281,8 @@ inner_auth_combo_init (EAPMethodTTLS *method,
 	em_pap = eap_method_simple_new (method->sec_parent,
 	                                connection,
 	                                EAP_METHOD_SIMPLE_TYPE_PAP,
-	                                simple_flags);
+	                                simple_flags,
+	                                NULL);
 	gtk_list_store_append (auth_model, &iter);
 	gtk_list_store_set (auth_model, &iter,
 	                    I_NAME_COLUMN, _("PAP"),
@@ -296,7 +297,8 @@ inner_auth_combo_init (EAPMethodTTLS *method,
 	em_mschap = eap_method_simple_new (method->sec_parent,
 	                                   connection,
 	                                   EAP_METHOD_SIMPLE_TYPE_MSCHAP,
-	                                   simple_flags);
+	                                   simple_flags,
+	                                   NULL);
 	gtk_list_store_append (auth_model, &iter);
 	gtk_list_store_set (auth_model, &iter,
 	                    I_NAME_COLUMN, _("MSCHAP"),
@@ -311,7 +313,8 @@ inner_auth_combo_init (EAPMethodTTLS *method,
 	em_mschap_v2 = eap_method_simple_new (method->sec_parent,
 	                                      connection,
 	                                      EAP_METHOD_SIMPLE_TYPE_MSCHAP_V2,
-	                                      simple_flags);
+	                                      simple_flags,
+	                                      NULL);
 	gtk_list_store_append (auth_model, &iter);
 	gtk_list_store_set (auth_model, &iter,
 	                    I_NAME_COLUMN, _("MSCHAPv2"),
@@ -327,7 +330,8 @@ inner_auth_combo_init (EAPMethodTTLS *method,
 	em_plain_mschap_v2 = eap_method_simple_new (method->sec_parent,
 	                                            connection,
 	                                            EAP_METHOD_SIMPLE_TYPE_PLAIN_MSCHAP_V2,
-	                                            simple_flags);
+	                                            simple_flags,
+	                                            NULL);
 	gtk_list_store_append (auth_model, &iter);
 	gtk_list_store_set (auth_model, &iter,
 	                    I_NAME_COLUMN, _("MSCHAPv2 (no EAP)"),
@@ -343,7 +347,8 @@ inner_auth_combo_init (EAPMethodTTLS *method,
 	em_chap = eap_method_simple_new (method->sec_parent,
 	                                 connection,
 	                                 EAP_METHOD_SIMPLE_TYPE_CHAP,
-	                                 simple_flags);
+	                                 simple_flags,
+	                                 NULL);
 	gtk_list_store_append (auth_model, &iter);
 	gtk_list_store_set (auth_model, &iter,
 	                    I_NAME_COLUMN, _("CHAP"),
@@ -358,7 +363,8 @@ inner_auth_combo_init (EAPMethodTTLS *method,
 	em_md5 = eap_method_simple_new (method->sec_parent,
 	                                connection,
 	                                EAP_METHOD_SIMPLE_TYPE_MD5,
-	                                simple_flags);
+	                                simple_flags,
+	                                NULL);
 	gtk_list_store_append (auth_model, &iter);
 	gtk_list_store_set (auth_model, &iter,
 	                    I_NAME_COLUMN, _("MD5"),
@@ -373,7 +379,8 @@ inner_auth_combo_init (EAPMethodTTLS *method,
 	em_gtc = eap_method_simple_new (method->sec_parent,
 	                                connection,
 	                                EAP_METHOD_SIMPLE_TYPE_GTC,
-	                                simple_flags);
+	                                simple_flags,
+	                                NULL);
 	gtk_list_store_append (auth_model, &iter);
 	gtk_list_store_set (auth_model, &iter,
 	                    I_NAME_COLUMN, _("GTC"),

--- a/src/wireless-security/wireless-security.c
+++ b/src/wireless-security/wireless-security.c
@@ -386,7 +386,6 @@ ws_802_1x_auth_combo_init (WirelessSecurity *sec,
 	EAPMethodFAST *em_fast;
 	EAPMethodTTLS *em_ttls;
 	EAPMethodPEAP *em_peap;
-	EAPMethodSimple *em_hints;
 	const char *default_method = NULL, *ctype = NULL;
 	int active = -1, item = 0;
 	gboolean wired = FALSE;
@@ -501,6 +500,8 @@ ws_802_1x_auth_combo_init (WirelessSecurity *sec,
 	item++;
 
 	if (secrets_hints) {
+		EAPMethodSimple *em_hints;
+
 		em_hints = eap_method_simple_new (sec, connection, EAP_METHOD_SIMPLE_TYPE_UNKNOWN,
 		                                  simple_flags, secrets_hints);
 		gtk_list_store_append (auth_model, &iter);
@@ -510,6 +511,20 @@ ws_802_1x_auth_combo_init (WirelessSecurity *sec,
 		                    -1);
 		eap_method_unref (EAP_METHOD (em_hints));
 		active = item;
+		item++;
+	} else if (default_method && !strcmp (default_method, "external")) {
+		EAPMethodSimple *em_extern;
+		const char *empty_hints[] = { NULL };
+
+		em_extern = eap_method_simple_new (sec, connection, EAP_METHOD_SIMPLE_TYPE_UNKNOWN,
+		                                   simple_flags, empty_hints);
+		gtk_list_store_append (auth_model, &iter);
+		gtk_list_store_set (auth_model, &iter,
+		                    AUTH_NAME_COLUMN, _("Externally configured"),
+		                    AUTH_METHOD_COLUMN, em_extern,
+		                    -1);
+		eap_method_unref (EAP_METHOD (em_extern));
+			active = item;
 		item++;
 	}
 

--- a/src/wireless-security/wireless-security.c
+++ b/src/wireless-security/wireless-security.c
@@ -373,7 +373,8 @@ ws_802_1x_auth_combo_init (WirelessSecurity *sec,
                            GCallback auth_combo_changed_cb,
                            NMConnection *connection,
                            gboolean is_editor,
-                           gboolean secrets_only)
+                           gboolean secrets_only,
+                           const char *const*secrets_hints)
 {
 	GtkWidget *combo, *widget;
 	GtkListStore *auth_model;
@@ -385,6 +386,7 @@ ws_802_1x_auth_combo_init (WirelessSecurity *sec,
 	EAPMethodFAST *em_fast;
 	EAPMethodTTLS *em_ttls;
 	EAPMethodPEAP *em_peap;
+	EAPMethodSimple *em_hints;
 	const char *default_method = NULL, *ctype = NULL;
 	int active = -1, item = 0;
 	gboolean wired = FALSE;
@@ -418,7 +420,7 @@ ws_802_1x_auth_combo_init (WirelessSecurity *sec,
 		simple_flags |= EAP_METHOD_SIMPLE_FLAG_SECRETS_ONLY;
 
 	if (wired) {
-		em_md5 = eap_method_simple_new (sec, connection, EAP_METHOD_SIMPLE_TYPE_MD5, simple_flags);
+		em_md5 = eap_method_simple_new (sec, connection, EAP_METHOD_SIMPLE_TYPE_MD5, simple_flags, NULL);
 		gtk_list_store_append (auth_model, &iter);
 		gtk_list_store_set (auth_model, &iter,
 			                AUTH_NAME_COLUMN, _("MD5"),
@@ -454,7 +456,7 @@ ws_802_1x_auth_combo_init (WirelessSecurity *sec,
 		item++;
 	}
 
-	em_pwd = eap_method_simple_new (sec, connection, EAP_METHOD_SIMPLE_TYPE_PWD, simple_flags);
+	em_pwd = eap_method_simple_new (sec, connection, EAP_METHOD_SIMPLE_TYPE_PWD, simple_flags, NULL);
 	gtk_list_store_append (auth_model, &iter);
 	gtk_list_store_set (auth_model, &iter,
 	                    AUTH_NAME_COLUMN, _("PWD"),
@@ -497,6 +499,19 @@ ws_802_1x_auth_combo_init (WirelessSecurity *sec,
 	if (default_method && (active < 0) && !strcmp (default_method, "peap"))
 		active = item;
 	item++;
+
+	if (secrets_hints) {
+		em_hints = eap_method_simple_new (sec, connection, EAP_METHOD_SIMPLE_TYPE_UNKNOWN,
+		                                  simple_flags, secrets_hints);
+		gtk_list_store_append (auth_model, &iter);
+		gtk_list_store_set (auth_model, &iter,
+		                    AUTH_NAME_COLUMN, "Unknown",
+		                    AUTH_METHOD_COLUMN, em_hints,
+		                    -1);
+		eap_method_unref (EAP_METHOD (em_hints));
+		active = item;
+		item++;
+	}
 
 	combo = GTK_WIDGET (gtk_builder_get_object (sec->builder, combo_name));
 	g_assert (combo);

--- a/src/wireless-security/wireless-security.h
+++ b/src/wireless-security/wireless-security.h
@@ -123,7 +123,8 @@ GtkWidget *ws_802_1x_auth_combo_init (WirelessSecurity *sec,
                                       GCallback auth_combo_changed_cb,
                                       NMConnection *connection,
                                       gboolean is_editor,
-                                      gboolean secrets_only);
+                                      gboolean secrets_only,
+                                      const char *const*secrets_hints);
 
 void ws_802_1x_auth_combo_changed (GtkWidget *combo,
                                    WirelessSecurity *sec,

--- a/src/wireless-security/ws-dynamic-wep.c
+++ b/src/wireless-security/ws-dynamic-wep.c
@@ -124,7 +124,8 @@ ws_dynamic_wep_new (NMConnection *connection,
 	                                    (GCallback) auth_combo_changed_cb,
 	                                    connection,
 	                                    is_editor,
-	                                    secrets_only);
+	                                    secrets_only,
+	                                    NULL);
 	auth_combo_changed_cb (widget, (gpointer) parent);
 
 	return (WirelessSecurityDynamicWEP *) parent;

--- a/src/wireless-security/ws-wpa-eap.c
+++ b/src/wireless-security/ws-wpa-eap.c
@@ -99,7 +99,8 @@ update_secrets (WirelessSecurity *parent, NMConnection *connection)
 WirelessSecurityWPAEAP *
 ws_wpa_eap_new (NMConnection *connection,
                 gboolean is_editor,
-                gboolean secrets_only)
+                gboolean secrets_only,
+                const char *const*secrets_hints)
 {
 	WirelessSecurity *parent;
 	GtkWidget *widget;

--- a/src/wireless-security/ws-wpa-eap.c
+++ b/src/wireless-security/ws-wpa-eap.c
@@ -126,7 +126,8 @@ ws_wpa_eap_new (NMConnection *connection,
 	                                    (GCallback) auth_combo_changed_cb,
 	                                    connection,
 	                                    is_editor,
-	                                    secrets_only);
+	                                    secrets_only,
+	                                    secrets_hints);
 	auth_combo_changed_cb (widget, parent);
 
 	return (WirelessSecurityWPAEAP *) parent;

--- a/src/wireless-security/ws-wpa-eap.h
+++ b/src/wireless-security/ws-wpa-eap.h
@@ -27,6 +27,7 @@ typedef struct _WirelessSecurityWPAEAP WirelessSecurityWPAEAP;
 
 WirelessSecurityWPAEAP * ws_wpa_eap_new (NMConnection *connection,
                                          gboolean is_editor,
-                                         gboolean secrets_only);
+                                         gboolean secrets_only,
+                                         const char *const*secrets_hints);
 
 #endif /* WS_WPA_EAP_H */


### PR DESCRIPTION
This is a proposal / RFC for handling the type of agent request made by the IWD wifi backend, where the specific EAP method is not known to NM (IWD doesn't expose that) but specific secrets are being requested using the 'hints' parameter so the client doesn't need to look at the actual connection settings to deduce which secrets might be missing.

Specifically the setting_name parameter in the request is set to "802-1x" and hints is one of "identity", "password" or "private_key_password" in this use case although other values could be supported in the same way.  I'm sort of abusing the EAPMethodSimple class in nm-applet, please see explanation in the commit messages.  It's not very pretty, other ideas to handle this will be welcome